### PR TITLE
Version/2.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.env
 /.idea
 /.vscode
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -751,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -784,6 +784,16 @@ name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -3887,9 +3897,10 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tmgr"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "clap",
+ "colored",
  "directories",
  "reqwest",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmgr"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 authors = ["Charlie Karafotias <cnkara2023@gmail.com>"]
 repository = "https://github.com/charliekarafotias/tmgr"
@@ -8,7 +8,7 @@ repository = "https://github.com/charliekarafotias/tmgr"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.5.17", features = ["derive"] }
+clap = { version = "4.5.18", features = ["derive"] }
 serde = { version = "1.0.210", features = ["derive"] }
 surrealdb = { version = "2.0.1", features = ["kv-mem", "kv-surrealkv"] }
 tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }
@@ -16,6 +16,7 @@ serde_json = "1.0.128"
 reqwest = { version = "0.12.7", features = ["json"] }
 semver = "1.0.23"
 directories = "5.0.1"
+colored = "2.1.0"
 
 [dev-dependencies]
 tempfile = "3.12.0"

--- a/README.md
+++ b/README.md
@@ -1,153 +1,175 @@
-# Todo Manager CLI (TMGR)
-A command line tool to track your tasks, organized using Sqlite3 databases.
+# Task Manager CLI: `tmgr`
+
+A command line tool to track tasks, designed for those that live in IDEs.
+
+### Key features include:
+
+- CRUD operations for tasks
+- Duration tracking for tasks
+- More to come in the future! Think Jira integration, labels, linking tasks to lines in code, etc.!
 
 ## Getting Started
 
-### Installation 
-- MacOS:
-    - Download the latest release from Github repository. The file to download is named `tmgr`.
+### Installation
+
+_DISCLAIMER_: There are several ways to install and start using `tmgr`. As I developed this on macOS, the directions
+provided below have only been tested on macOS and may not work as well on other platforms. I look to expand on this in
+the future as the project matures.
+
+- **macOS - downloading the binary from latest release (use if you do not have/want to install Rust)**:
+    - Download the latest release from GitHub repository. The file to download is under assets named `tmgr`.
         - [Release page (latest)](https://github.com/CharlieKarafotias/tmgr/releases/latest)
-        - [Direct download link (v0.4.1)](https://github.com/CharlieKarafotias/tmgr/releases/download/v0.4.1/tmgr)
     - In the downloads folder, you should see a new file named `tmgr`
-    - Open terminal and run the command `cd Downloads && chmod 751 ./tmgr`. This command will move your directory to the downloads folder and make `tmgr` an executable program
-    - Move `tmgr` program to one of your computer's bin folders. For info on what a bin is, [see this resource](https://apple.stackexchange.com/questions/99788/os-x-create-a-personal-bin-directory-bin-and-run-scripts-without-specifyin) on creating a personal bin and setting the path for your terminal.
-    - Once set up, open a terminal and run `tmgr`. If successful, you should see all the available subcommands listed by default as the response.
+    - Open terminal and run the command `cd Downloads && chmod 751 ./tmgr`. This command will move your directory to the
+      downloads folder and make `tmgr` an executable program
+    - Move `tmgr` program to one of your computer's bin folders. For info on what a bin
+      is, [see this resource](https://apple.stackexchange.com/questions/99788/os-x-create-a-personal-bin-directory-bin-and-run-scripts-without-specifyin)
+      on creating a personal bin and setting the path for your terminal.
+    - Once set up, open a terminal and run `tmgr`. If successful, you should see all the available commands listed by
+      default as the response.
+- **macOS - building from source**:
+    - Requirements:
+        - [Install Rust](https://www.rust-lang.org/tools/install) (if not installed)
+        - [Install Git](https://git-scm.com/downloads) (if not installed)
+    - Go to [tmgr repository](https://github.com/CharlieKarafotias/tmgr/) and clone it to your computer.
+      Alternatively, run `git clone https://github.com/CharlieKarafotias/tmgr.git`
+    - Open terminal and change directory to the `tmgr` folder
+    - Run `cargo build -r`. This will build a release version of the project for your system.
+    - Once complete, the release version should be in at `tmgr/target/release/tmgr`.
+    - Move the `tmgr` binary to one of your computer's bin folders.
+    - Once set up, open a terminal and run `tmgr`. If successful, you should see all the available commands listed out.
 
 ### Development Setup
+
 If you wish to change the source code, you can follow the steps below:
-1. Install Rust on your computer. For instructions on installing Rust, see the [Rust installation guide](https://www.rust-lang.org/tools/install).
+
+1. Install Rust on your computer. For instructions on installing Rust, see
+   the [Rust installation guide](https://www.rust-lang.org/tools/install).
 2. Pull this repository
-3. Run `cargo run`. This should compile tmgr and then return all the commands that are available for the program. 
-4. To run a specific command, such as adding a new task, use the following command `cargo run -- todo add "my first todo"`
+3. Run `cargo run`. This should compile `tmgr` and then return all the commands that are available for the program.
+4. To run a specific command, such as adding a new task, use the following command `cargo run -- add "my first todo"`
 5. To build an optimized release of the project, run `cargo build -r`
-6. If you wish to commit to this repo, before opening a pull request, ensure [Pre-commit](https://pre-commit.com/#install) is installed on your computer. This project utilizes pre-commit to ensure consistency throughout commits.
+6. If you wish to commit to this repo, before opening a pull request,
+   ensure [Pre-commit](https://pre-commit.com/#install) is installed on your computer. This project utilizes pre-commit
+   to ensure consistency throughout commits.
 
-## CLI Commands 
+## CLI Commands
 
-`tmgr` has 6 types of commands
-1. `database`
-2. `init`
-3. `status`
-4. `todo`
-5. `update`
-6. `help`
+`tmgr` has the following commands:
 
-### Database Commands 
+### Command Reference
 
-Database commands manage the state of the sqlite3 database that store tasks.
-- `add`: Adds a new database inside the databases directory
-    - Arguments:
-        - NAME: The database name
-    - Example:
-        - `tmgr database add 2024Tasks`
-- `delete`: Deletes a database inside the databases directory (if found)
-    - Arguments:
-        - NAME: The database name
-    - Example:
-        - `tmgr database delete 2024Tasks`
-- `list`: Lists all databases by name stored inside the databases directory
-    - Arguments:
-        - None
-    - Example:
-        - `tmgr database list`
-- `set`: Sets the current working database (to add/remove tasks from). This must be a database located in the databases directory.
-    - Arguments:
-        - Name: The database name
-    - Example:
-        - `tmgr database set 2024Tasks`
-- `set-directory`: Sets the working directory of where databases are stored. This can be used if you wish to change the default location set by `tmgr` on initialization.
-    - Arguments:
-        - Path: The directory path
-    - Example: 
-        - `tmgr database set-directory /Users/Charlie/databases`
-- `help`: Prints out a helpful message showing what each subcommand does
+| Command Name | Description                                                         |
+|--------------|---------------------------------------------------------------------|
+| add          | adds a new task                                                     |
+| complete     | marks a task as complete                                            |
+| delete       | deletes a task                                                      |
+| list         | lists tasks                                                         |
+| status       | info regarding file locations, current database, general statistics |
+| update       | updates an existing task                                            |
+| upgrade      | upgrades `tmgr` to the latest version                               |
+| view         | shows all information about a specific task                         |
+| help         | prints out CLI usage information                                    |
 
-### Init Command
 
-Initializes tmgr for first time use. This consists of running 3 subcommands from the databases subcommand list:
-- `tmgr database set-directory .`
-- `tmgr database add init-db`
-- `tmgr database set init-db`
+### Add Command
 
-If successful, a message stating _Initializer complete!_ will show.
+The `add` command will add a new task.
 
-- Arguments: 
-    - No arguments
-- Example: 
-    - `tmgr init`
+#### Usage
+
+- `tmgr add <Name> [Priority] [Description]`
+    - Note: Priority has 3 possible values: `low`, `medium`, and `high`.
+    - If no priority is provided, it will default to `high`.
+- `tmgr add 'The most basic task... just a name is set'`
+- `tmgr add 'Read AWS document' 'low' 'Read the concurrent execution section of the lambda documentation'`
+    - Where `Read AWS document` is the name of the task
+    - Where `low` is the priority of the task
+    - Where `Read the concurrent execution section of the lambda documentation` is the description of the task
+
+### Complete Command
+
+The `complete` command will mark a task as complete.
+
+#### Usage
+
+- `tmgr complete <ID>`
+- `tmgr complete '1w08w2'`
+    - Where `1w08w2` is the beginning part of an existing task ID. To find task IDs, run `tmgr list`
+
+### Delete Command
+
+The `delete` command will delete a task.
+
+#### Usage
+
+- `tmgr delete <ID>`
+- `tmgr delete '1w08w2'`
+    - Where `1w08w2` is the beginning part of an existing task ID. To find task IDs, run `tmgr list`
+
+### List Command
+
+Lists all tasks. By default, this will only list in-progress tasks. This provides general information about the tasks
+like the name, priority, and description.
+
+#### Usage 
+
+- `tmgr list`
+- `tmgr list -a`
+    - List all tasks (includes completed tasks)
 
 ### Status Command
 
-The status command provides the user with the internal workings of `tmgr`. This includes information about the following:
-- State Manager variables: 
-    - The location of the database folder
-    - The current database selected
-- The total amount of tasks in the current database
+The `status` command will show information regarding the current state & location of the database and information about
+the location of the binary.
 
-More data will be added as development progresses
+#### Usage
 
-- Arguments:
-    - No arguments
-- Example: 
-    - `tmgr status`
-
-### Todo Commands 
-
-Todo commands manage the state of a task inside the current working database.
-- `add`: Adds a new task
-    - Arguments:
-        - `Name`: A short description of the task
-        - `Priority` (default high): The priority of the task [possible values: low, medium, high]
-        - `Description` (optional): A long description of the task
-    - Example(s):
-        - `tmgr todo add "Read AWS document"`
-        - `tmgr todo add "Read AWS document" low "Read the concurrent execution section of the lambda documentation"`
-- `complete`: Mark a task as complete
-    - Arguments:
-        - `ID`: The id of the task
-    - Example
-        - `tmgr todo complete 1`
-- `delete`: Delete a task
-    - Arguments:
-        - `ID`: The id of the task
-    - Example
-        - `tmgr todo delete 1`
-- `list`: List all tasks
-    - Arguments:
-        - None
-    - Example:
-        - `tmgr todo list`
-- `update`: Update an existing task
-    - Arguments:
-        - `ID`: The id of the task
-        - `Name` (Optional): A short description of the task
-        - `Priority` (Optional): The priority of the task [possible values: low, medium, high]
-        - `Description` (Optional): A long description of the task
-    - Example:
-        - `tmgr todo update 2024Tasks`
-- `help`: Prints out a helpful message showing what each subcommand does
+- `tmgr status`
 
 ### Update Command
-This command updates `tmgr` to the latest stable version. The command works in the following steps: 
-1. Checks the latest release version on the Github repository
+
+The `update` command will update information about a particular task.
+
+#### Usage
+
+- `tmgr update <ID> [Name] [Priority] [Description]`
+    - Note: Priority has 3 possible values: `low`, `medium`, and `high`.
+- `tmgr update '1w08w2' 'Read AWS document' 'low' 'Read the concurrent execution section of the lambda documentation'`
+    - Updates the name, priority, and description of the task starting with ID `1w08w2`.
+
+### Upgrade Command
+
+The `upgrade` command will update `tmgr` to the latest version. The command works in the following steps:
+
+1. Checks the latest release version on the GitHub repository
 2. Checks if a version update is needed
-3. If needed, the latest release is downloaded from Github repository and stored in the system's downloads folder.
-4. Locate where the current `tmgr` executable is stored 
+3. If needed, the latest release is downloaded from GitHub repository and stored in the system's downloads folder.
+4. Locate where the current `tmgr` executable is stored
 5. Delete the current `tmgr` executable
-6. Move the latest `tmgr` executable from the downloads folder to the folder where the current `tmgr` executable was just deleted from.
+6. Move the latest `tmgr` executable from the downloads folder to the folder where the current `tmgr` executable was
+   just deleted from.
 
-### Help Command 
+#### Usage
 
-The help command will present all available subcommands that TMGR supports. Further, help can be used within other subcommands to learn more about each commands functionality. 
+- `tmgr upgrade`
 
-Example: 
+### View Command
+
+The `view` command will show all information about a specific task.
+
+#### Usage
+
+- `tmgr view <ID>`
+- `tmgr view '1w08w2'`
+    - Where `1w08w2` is the beginning part of an existing task ID. To find task IDs, run `tmgr list`
+
+### Help Command
+
+The help command will present all available subcommands that `tmgr` supports. Further, help can be used within other
+subcommands to learn more about each commands' functionality.
+
+#### Usage
+
 - `tmgr -h`
 - `tmgr --help`
-
-## Behind The Scenes:
-
-### Persistent Storage
-
-TMGR utilizes a [toml](https://toml.io/en/) file to store state between sessions. The following variables are tracked in the `tmgr_config.toml` file:
-- db_var: Stores the current database. This can be set by the user by running the command `tmgr database set {database_name}`.
-- db_dir: Stores the save location of databases for the program. This can be set by the user by running the command `tmgr database set-directory {path}`.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+# 2.1.0
+
+- Improved result handling experience by standardizing approach to errors in `tmgr`
+- Fixed issue where commands were printing results where String was derived from `Debug` trait. [See here](https://github.com/CharlieKarafotias/tmgr/issues/73#issuecomment-2365190468) for details.
+- Fixed exit codes for project:
+    - `0` for success
+    - `1` for general errors
+    - `2` for CLI usage errors
+- `clap` dependency bumped to v4.5.18
+
 # 2.0.0
 
 - Updated to use version 2 of SurrealDB

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -9,6 +9,7 @@
     - `1` for general errors
     - `2` for CLI usage errors
 - `clap` dependency bumped to v4.5.18
+- Updated readme
 
 # 2.0.0
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,2 +1,4 @@
 pub mod model;
 pub mod parser;
+pub mod result_handler;
+mod tests;

--- a/src/cli/result_handler.rs
+++ b/src/cli/result_handler.rs
@@ -1,0 +1,27 @@
+use colored::Colorize;
+
+enum ExitCode {
+    Success = 0,
+    Failure = 1,
+}
+pub(crate) struct ResultHandler {
+    pub(crate) result_string: String,
+    pub(crate) exit_code: i32,
+}
+pub(crate) async fn handle_result(
+    result: Result<String, Box<dyn std::error::Error>>,
+) -> ResultHandler {
+    match result {
+        Ok(res) => ResultHandler {
+            result_string: res,
+            exit_code: ExitCode::Success as i32,
+        },
+        Err(err) => {
+            let response = format!("{}: {err}", "error".red());
+            ResultHandler {
+                result_string: response,
+                exit_code: ExitCode::Failure as i32,
+            }
+        }
+    }
+}

--- a/src/cli/tests/mod.rs
+++ b/src/cli/tests/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod result_handler_test;

--- a/src/cli/tests/result_handler_test.rs
+++ b/src/cli/tests/result_handler_test.rs
@@ -1,0 +1,32 @@
+use crate::cli::result_handler::handle_result;
+use colored::Colorize;
+use std::error::Error;
+
+#[tokio::test]
+async fn given_ok_result_when_handling_result_then_passed_in_string_should_be_returned() {
+    let result = Ok("ok".to_string());
+    let handler = handle_result(result).await;
+    assert_eq!(handler.result_string, "ok".to_string());
+}
+
+#[tokio::test]
+async fn given_ok_result_when_handling_result_then_exit_code_0_should_be_returned() {
+    let result = Ok("ok".to_string());
+    let handler = handle_result(result).await;
+    assert_eq!(handler.exit_code, 0);
+}
+
+#[tokio::test]
+async fn given_error_result_when_handling_result_then_error_string_should_be_returned() {
+    let result: Result<String, Box<dyn Error>> = Err("An error occurred:".into());
+    let handler = handle_result(result).await;
+    let expected = format!("{}: An error occurred:", "error".red());
+    assert_eq!(handler.result_string, expected);
+}
+
+#[tokio::test]
+async fn given_error_result_when_handling_result_then_exit_code_1_should_be_returned() {
+    let result: Result<String, Box<dyn Error>> = Err("An error occurred:".into());
+    let handler = handle_result(result).await;
+    assert_eq!(handler.exit_code, 1);
+}

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -16,8 +16,8 @@ pub(crate) async fn run(db: &DB, all: bool) -> Result<String, Box<dyn std::error
         .into_iter()
         .map(|t| {
             format!(
-                "ID: {:?}: {} - {} ({})",
-                t.id,
+                "ID: {}: {} - {} ({})",
+                t.id.unwrap_or_else(|| "Unable to determine ID".to_string()),
                 t.name,
                 t.description.unwrap_or_default(),
                 t.priority

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 mod cli;
 mod commands;
-
 use cli::parser;
 
 fn main() {
-    parser::run();
+    let exit_code: i32 = parser::run();
+    std::process::exit(exit_code);
 }


### PR DESCRIPTION
# 2.1.0

- Improved result handling experience by standardizing approach to errors in `tmgr`
- Fixed issue where commands were printing results where String was derived from `Debug` trait. [See here](https://github.com/CharlieKarafotias/tmgr/issues/73#issuecomment-2365190468) for details.
- Fixed exit codes for project:
    - `0` for success
    - `1` for general errors
    - `2` for CLI usage errors
- `clap` dependency bumped to v4.5.18
- Updated readme