### PR TITLE
96 - corrected print out of task, no longer has task: prefix

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -25,8 +25,7 @@ pub(crate) async fn run(
         .map_err(|_| format!("Failed to create task '{name}'."))?;
 
     if let Some(task) = task {
-        let id = task.id.unwrap_or_default();
-        Ok(format!("Task '{id}' created successfully"))
+        Ok(format!("Task '{}' created successfully", task.get_id()?))
     } else {
         Err("Failed to create task".to_string().into())
     }

--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -9,9 +9,11 @@ pub(crate) async fn run(db: &DB, id: String) -> Result<String, Box<dyn std::erro
 
     let _: Option<Task> = db
         .client
-        .upsert(("task", task_id))
+        .upsert(("task", &task_id))
         .patch(PatchOp::replace("/completed_at", Datetime::default()))
         .await?;
 
-    Ok(format!("Successfully updated task '{id}' to completed"))
+    Ok(format!(
+        "Successfully updated task '{task_id}' to completed"
+    ))
 }

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -19,5 +19,5 @@ pub(crate) async fn run(db: &DB, id: String) -> Result<String, Box<dyn std::erro
         }
     }
 
-    Ok(format!("Successfully deleted task starting with id '{id}'"))
+    Ok(format!("Successfully deleted task '{task_id}'"))
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -24,7 +24,7 @@ pub(crate) async fn run(db: &DB, all: bool) -> Result<String, Box<dyn std::error
 
     for t in tasks {
         table.add_row(vec![
-            &t.id.unwrap_or("Unable to determine ID".to_string()),
+            &t.get_id()?,
             &t.name,
             &t.priority,
             &t.description.unwrap_or_default(),

--- a/src/commands/tests/delete_test.rs
+++ b/src/commands/tests/delete_test.rs
@@ -23,10 +23,7 @@ async fn given_existing_tasks_when_deleting_a_task_then_the_task_should_be_delet
     let res = delete::run(&db, id.clone()).await;
     assert!(res.is_ok());
     let res_str = res.unwrap();
-    assert_eq!(
-        res_str,
-        format!("Successfully deleted task starting with id '{id}'")
-    );
+    assert_eq!(res_str, format!("Successfully deleted task '{id}'"));
 
     let res: Vec<Task> = db.client.select("task").await.unwrap();
     assert_eq!(res.len(), 0);

--- a/src/commands/tests/update_test.rs
+++ b/src/commands/tests/update_test.rs
@@ -48,10 +48,7 @@ async fn given_existing_tasks_when_updating_a_priority_field_then_only_that_fiel
     let res = update::run(&db, id.clone(), None, Some(TaskPriority::High), None).await;
     assert!(res.is_ok());
     let res_str = res.unwrap();
-    assert_eq!(
-        res_str,
-        format!("Successfully updated task starting with id '{id}'")
-    );
+    assert_eq!(res_str, format!("Successfully updated task '{id}'"));
 
     let res: Vec<Task> = db.client.select("task").await.unwrap();
     assert_eq!(res.len(), 1);
@@ -82,10 +79,7 @@ async fn given_existing_tasks_when_updating_a_description_field_then_only_that_f
     .await;
     assert!(res.is_ok());
     let res_str = res.unwrap();
-    assert_eq!(
-        res_str,
-        format!("Successfully updated task starting with id '{id}'")
-    );
+    assert_eq!(res_str, format!("Successfully updated task '{id}'"));
 
     let res: Vec<Task> = db.client.select("task").await.unwrap();
     assert_eq!(res.len(), 1);
@@ -110,10 +104,7 @@ async fn given_existing_tasks_when_updating_the_name_then_only_that_field_should
     let res = update::run(&db, id.clone(), Some("test2".to_string()), None, None).await;
     assert!(res.is_ok());
     let res_str = res.unwrap();
-    assert_eq!(
-        res_str,
-        format!("Successfully updated task starting with id '{id}'")
-    );
+    assert_eq!(res_str, format!("Successfully updated task '{id}'"));
 
     let res: Vec<Task> = db.client.select("task").await.unwrap();
     assert_eq!(res.len(), 1);
@@ -149,10 +140,7 @@ async fn given_existing_tasks_when_updating_multiple_fields_then_only_those_fiel
     .await;
     assert!(res.is_ok());
     let res_str = res.unwrap();
-    assert_eq!(
-        res_str,
-        format!("Successfully updated task starting with id '{id}'")
-    );
+    assert_eq!(res_str, format!("Successfully updated task '{id}'"));
 
     let res: Vec<Task> = db.client.select("task").await.unwrap();
     assert_eq!(res.len(), 1);

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -32,9 +32,9 @@ pub(crate) async fn run(
 
     let _: Option<Task> = db
         .client
-        .update(("task", task_id))
+        .update(("task", &task_id))
         .merge(update_map)
         .await?;
 
-    Ok(format!("Successfully updated task starting with id '{id}'"))
+    Ok(format!("Successfully updated task '{task_id}'"))
 }

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -8,10 +8,7 @@ pub(crate) async fn run(db: &DB, id: String) -> Result<String, Box<dyn std::erro
     table
         .set_content_arrangement(comfy_table::ContentArrangement::Dynamic)
         .set_header(vec!["Key", "Value"])
-        .add_row(vec![
-            "id",
-            &t.id.unwrap_or("Unable to determine ID".to_string()),
-        ])
+        .add_row(vec!["id", &t.get_id()?])
         .add_row(vec!["name", &t.name])
         .add_row(vec!["priority", &t.priority])
         .add_row(vec!["description", &t.description.unwrap_or_default()])


### PR DESCRIPTION
- Corrects printout of task ids. There is no longer `task:` prefix on ids
- Updates wording from `task starting with id` to `task 'id'`